### PR TITLE
feat(ga4): keeps the _gl parameter on redirections

### DIFF
--- a/lib/actions/authorization/respond.js
+++ b/lib/actions/authorization/respond.js
@@ -26,6 +26,12 @@ module.exports = provider => async function respond(ctx, next) {
     }
   }
 
+  /* eslint-disable no-underscore-dangle */
+  if (ctx.req.query._gl) {
+    out._gl = ctx.req.query._gl;
+  }
+  /* eslint-enable no-underscore-dangle */
+
   provider.emit('authorization.success', ctx);
   debug('uuid=%s %o', uuid, out);
 

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -224,7 +224,15 @@ class Provider extends events.EventEmitter {
    * @api public
    */
   async interactionFinished(req, res, result) {
-    const returnTo = await this.interactionResult(req, res, result);
+    let returnTo = await this.interactionResult(req, res, result);
+
+    /* eslint-disable no-underscore-dangle */
+    if (req.query._gl) {
+      const parsedReturnToo = new URL(returnTo);
+      parsedReturnToo.searchParams.append('_gl', req.query._gl);
+      returnTo = parsedReturnToo.toString();
+    }
+    /* eslint-enable no-underscore-dangle */
 
     res.statusCode = 302; // eslint-disable-line no-param-reassign
     res.setHeader('Location', returnTo);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gmsllc/oidc-provider",
-  "version": "5.5.7",
+  "version": "5.5.8",
   "description": "OpenID Provider (OP) implementation for Node.js OpenID Connect servers.",
   "keywords": [
     "auth",


### PR DESCRIPTION
We need to keep the `_gl` search parameter for google analytics 4 cross-domain tracking.

The simplest way to do this is to check if the current request has it, and if so, add it to whatever redirect the OIDC provider is doing.

## interactionFinished
This is doing a redirection to /auth/[UUID]

It's part of the OIDC flow, we need to keep the parameter in the URL for later.

## respond

This is redirecting to the redirect_url

In this function, the original Express.js req incoming message instance, can be found at `ctx.req`